### PR TITLE
Add RemoteStream to exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import Client from './client';
-import { LocalStream, Stream, StreamOptions } from './stream';
+import { LocalStream, RemoteStream, Stream, StreamOptions } from './stream';
 import { Codec } from './transport';
 
-export { Client, Codec, LocalStream, Stream, StreamOptions };
+export { Client, Codec, LocalStream, RemoteStream, Stream, StreamOptions };


### PR DESCRIPTION
#### Description

The README indicates that RemoteStream should be importable from ion-sdk-js, but it wasn't being exported.