### PR TITLE
iOS - fixing sending the stream

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -85,6 +85,7 @@ export class LocalStream extends Stream {
   constructor(stream: MediaStream, options: StreamOptions) {
     super(stream);
     this.options = options;
+    Object.setPrototypeOf(this, LocalStream.prototype);
   }
 
   private getVideoConstraints() {
@@ -205,6 +206,10 @@ export class LocalStream extends Stream {
 }
 
 export class RemoteStream extends Stream {
+  constructor(stream: MediaStream) {
+    super(stream);
+    Object.setPrototypeOf(this, RemoteStream.prototype);
+  }
   static async getRemoteMedia(rid: string, mid: string, tracks: Map<string, TrackInfo[]>) {
     const allTracks = Array.from(tracks.values()).flat();
     const audio = allTracks.map((t) => t.type.toLowerCase() === 'audio').includes(true);


### PR DESCRIPTION
#### Description
As per #26, extending native MediaStream doesn't work in Safari.

With this fix in place, I'm able to stream from my iPad.

For whatever reason, I cannot receive the stream. I don't know if that's my app, or there is still something that is missing.

There are no errors in the console that I can see in my app. Could someone with a Mac and an iPad test if they are receiving the stream, please?

#### Reference issue
Fixes #26
