### PR TITLE
Adding multiple local streams support to client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -121,11 +121,11 @@ export default class Client extends EventEmitter {
         rid: this.rid,
         uid: this.uid,
       });
-      for (const localStream of this.localStreams) {
+      await Promise.all(this.localStreams.map(async (localStream) => {
         if (localStream.mid) {
-          await localStream.unpublish()
+          await localStream.unpublish();
         }
-      }
+      }));
       this.localStreams = []
       Object.values(this.streams).forEach((stream) => stream.unsubscribe());
       this.knownStreams.clear();


### PR DESCRIPTION

#### Description
In some use cases, user needs to create multiple local streams. For example, having only an audio call that can at some point be upgraded to video call as well. Even more common scenario is video call with screen share. In those cases new local stream publish would override the previous stream. This PR implements bookkeeping for multiple local streams.

