### PR TITLE
Add description field to media stream

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -146,12 +146,12 @@ export default class Client extends EventEmitter {
         break;
       }
       case 'stream-add': {
-        const { mid, info, tracks } = data;
+        const { mid, info, tracks, description } = data;
         if (mid) {
           const trackMap: Map<string, TrackInfo[]> = objToStrMap(tracks);
           this.knownStreams.set(mid, trackMap);
         }
-        this.emit('stream-add', mid, info);
+        this.emit('stream-add', mid, info, description);
         break;
       }
       case 'stream-remove': {

--- a/src/proto.ts
+++ b/src/proto.ts
@@ -15,5 +15,6 @@ export interface Notification {
     uid: string;
     info?: string;
     tracks?: { [name: string]: TrackInfo };
+    description?: string;
   };
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -19,6 +19,7 @@ export interface StreamOptions extends MediaStreamConstraints {
   resolution: string;
   bandwidth?: number;
   codec: string;
+  description?: string;
 }
 
 export class Stream extends MediaStream {
@@ -148,7 +149,7 @@ export class LocalStream extends Stream {
   }
 
   async publish(rid: string) {
-    const { bandwidth, codec } = this.options!;
+    const { bandwidth, codec, description } = this.options!;
     let sendOffer = true;
     this.transport = new WebRTCTransport(codec as Codec);
     this.getTracks().map((track) => this.transport!.addTrack(track, this));
@@ -169,6 +170,7 @@ export class LocalStream extends Stream {
           options: {
             codec,
             bandwidth: Number(bandwidth),
+            description,
           },
         });
         this.mid = result.mid;


### PR DESCRIPTION
#### Depends on: [https://github.com/pion/ion/pull/340](https://github.com/pion/ion/pull/340)

#### Description
In some cases there is a business need to distinguish media streams on remote end. For example: client can implement diferent logic and visualisation for screenshare than camera stream. This allows adding additional metadata in form of 'description' field to media stream that will be propagated to remote end.


#### Reference issue
Fixes #...
