### PR TITLE
Update ion-sfu.ts

### DIFF
--- a/src/signal/ion-sfu.ts
+++ b/src/signal/ion-sfu.ts
@@ -44,8 +44,8 @@ export default class IonSFUJSONRPCSignal implements Signal {
         const resp = JSON.parse(event.data);
         if (resp.id === id) {
           resolve(resp.result);
+          this.socket.removeEventListener('message', handler);
         }
-        this.socket.removeEventListener('message', handler);
       };
       this.socket.addEventListener('message', handler);
     });


### PR DESCRIPTION
JSONRPCSignal's join method creates an event handler listening for a jsonrpc response with `resp.id == join_call.id` -- however, the event handler is currently immediately removed after the first message is received (whether or not it is the reply to the Join message); the event handler should not be removed until the correct reply is recieved.