### PR TITLE
Adds Protos to /lib during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lib/**/*"
   ],
   "scripts": {
-    "addProtosToBuild": "mkdir ./lib/signal/_proto && mkdir ./lib/signal/_proto/library && cp -r ./src/signal/_proto/library ./lib/signal/_proto",
+    "addProtosToBuild": "[ -d ./lib/signal/_proto/library ] || (mkdir ./lib/signal/_proto && mkdir ./lib/signal/_proto/library) && cp -r ./src/signal/_proto/library ./lib/signal/_proto",
     "build": "tsc && npm run addProtosToBuild",
     "bundle": "webpack",
     "dev": "tsc -w",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lib/**/*"
   ],
   "scripts": {
-    "build": "tsc",
+    "addProtosToBuild": "mkdir ./lib/signal/_proto && mkdir ./lib/signal/_proto/library && cp -r ./src/signal/_proto/library ./lib/signal/_proto",
+    "build": "tsc && npm run addProtosToBuild",
     "bundle": "webpack",
     "dev": "tsc -w",
     "format": "prettier --write \"src/**/*.ts\"",


### PR DESCRIPTION
#### Description
Automatically creates `/lib/signal/_proto/library` and moves the compiled protos into this directory during build. 


#### Reference issue
Fixes #145 
