### PR TITLE
(feat) simplify sdp audio opus

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -235,27 +235,24 @@ export class LocalStream extends MediaStream {
           direction: 'sendonly',
           sendEncodings: encodings,
         });
-        this.setPreferredCodec(transceiver);
+        this.setPreferredCodec(transceiver, track.kind);
       } else {
         const transceiver = this.pc.addTransceiver(track, {
           streams: [this],
           direction: 'sendonly',
           sendEncodings: track.kind === 'video' ? [VideoConstraints[this.constraints.resolution].encodings] : undefined,
         });
-
-        if (track.kind === 'video') {
-          this.setPreferredCodec(transceiver);
-        }
+        this.setPreferredCodec(transceiver, track.kind);
       }
     }
   }
 
-  private setPreferredCodec(transceiver: RTCRtpTransceiver) {
+  private setPreferredCodec(transceiver: RTCRtpTransceiver, kind: string) {
     if ('setCodecPreferences' in transceiver) {
-      const cap = RTCRtpSender.getCapabilities('video');
+      const cap = RTCRtpSender.getCapabilities(kind);
       if (!cap) return;
       const selCodec = cap.codecs.find(
-        (c) => c.mimeType === `video/${this.constraints.codec.toUpperCase()}` || c.mimeType === `audio/OPUS`,
+        (c) => c.mimeType.toLowerCase() === `video/${this.constraints.codec.toLowerCase()}` || c.mimeType.toLowerCase() === `audio/opus`
       );
       if (selCodec) {
         transceiver.setCodecPreferences([selCodec]);


### PR DESCRIPTION
#### Description
this will simplify the audio section
delete the unused lines

↵m=audio 9 UDP/TLS/RTP/SAVPF 111 ~~103 104 9 0 8 106 105 13 110 112 113 126~~
↵c=IN IP4 0.0.0.0
↵a=rtcp:9 IN IP4 0.0.0.0
↵a=ice-ufrag:+Lgl
↵a=ice-pwd:U/lEIPiHSKNV/cGgZNqPXewn
↵a=ice-options:trickle
↵a=fingerprint:sha-256 FA:26:3E:FD:42:92:A9:07:49:6E:6C:69:92:C5:0F:8E:B1:2D:DA:76:1A:93:6F:DE:79:AF:BD:96:69:32:79:B6
↵a=setup:actpass
↵a=mid:1
↵a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
↵a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
↵a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
↵a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid
↵a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
↵a=extmap:6 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
↵a=sendonly
↵a=msid:d825856d-0f72-416f-9293-2a3ad692eb5c d4497d7d-7504-4d13-92b5-c8b62f16a947
↵a=rtcp-mux
↵a=rtpmap:111 opus/48000/2
↵a=rtcp-fb:111 transport-cc
↵a=fmtp:111 minptime=10;useinbandfec=1
~~↵a=rtpmap:103 ISAC/16000
↵a=rtpmap:104 ISAC/32000
↵a=rtpmap:9 G722/8000
↵a=rtpmap:0 PCMU/8000
↵a=rtpmap:8 PCMA/8000
↵a=rtpmap:106 CN/32000
↵a=rtpmap:105 CN/16000
↵a=rtpmap:13 CN/8000
↵a=rtpmap:110 telephone-event/48000
↵a=rtpmap:112 telephone-event/32000
↵a=rtpmap:113 telephone-event/16000
↵a=rtpmap:126 telephone-event/8000~~
↵a=ssrc:2836429728 cname:D+S6PgkylaJrARFa
↵a=ssrc:2836429728 msid:d825856d-0f72-416f-9293-2a3ad692eb5c d4497d7d-7504-4d13-92b5-c8b62f16a947
↵a=ssrc:2836429728 mslabel:d825856d-0f72-416f-9293-2a3ad692eb5c
↵a=ssrc:2836429728 label:d4497d7d-7504-4d13-92b5-c8b62f16a947

#### Reference issue
Fixes #...
