### PR TITLE
Allow layer selection for publisher

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -18,6 +18,12 @@ export interface Trickle {
   target: Role;
 }
 
+export interface ActiveLayer {
+  streamId: string,
+  activeLayer: string,
+  availableLayers: string[]
+}
+
 enum Role {
   pub = 0,
   sub = 1,
@@ -73,6 +79,7 @@ export default class Client {
     offer?: RTCSessionDescriptionInit,
     answer?: RTCSessionDescriptionInit,
   ) => void;
+  onactivelayer?: (al: ActiveLayer) => void;
 
   constructor(
     signal: Signal,
@@ -111,9 +118,14 @@ export default class Client {
       this.transports![Role.sub].pc.ondatachannel = (ev: RTCDataChannelEvent) => {
         if (ev.channel.label === API_CHANNEL) {
           this.transports![Role.sub].api = ev.channel;
+          this.transports![Role.pub].api = ev.channel;
           ev.channel.onmessage = (e) => {
-            if (this.onspeaker) {
-              this.onspeaker(JSON.parse(e.data));
+            try {
+              const msg = JSON.parse(e.data);
+              this.processChannelMessage(msg);
+            } catch (err) {
+              /* tslint:disable-next-line:no-console */
+              console.error(err);
             }
           };
           resolve();
@@ -162,7 +174,7 @@ export default class Client {
     if (!this.transports) {
       throw Error(ERR_NO_SESSION);
     }
-    stream.publish(this.transports[Role.pub].pc);
+    stream.publish(this.transports[Role.pub]);
   }
 
   createDataChannel(label: string) {
@@ -226,6 +238,30 @@ export default class Client {
       /* tslint:disable-next-line:no-console */
       console.error(err);
       if (this.onerrnegotiate) this.onerrnegotiate(Role.pub, err, offer, answer);
+    }
+  }
+
+  private processChannelMessage(msg: any) {
+    if (msg.method !== undefined && msg.params !== undefined) {
+      switch (msg.method) {
+        case "audioLevels":
+          if (this.onspeaker) {
+            this.onspeaker(msg.params);
+          }
+          break;
+        case "activeLayer":
+          if (this.onactivelayer) {
+            this.onactivelayer(msg.params);
+          }
+          break;
+        default:
+          // do nothing
+      }
+    } else {
+      // legacy channel message - payload contains audio levels
+      if (this.onspeaker) {
+        this.onspeaker(msg)
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import Client from './client';
-import { LocalStream, RemoteStream, Constraints } from './stream';
+import { LocalStream, RemoteStream, Constraints, Layer } from './stream';
 import { Signal, Trickle } from './signal';
-export { Client, LocalStream, RemoteStream, Constraints, Signal, Trickle };
+export { Client, LocalStream, RemoteStream, Constraints, Signal, Trickle, Layer };


### PR DESCRIPTION
**Related to: [https://github.com/pion/ion-sfu/pull/477](https://github.com/pion/ion-sfu/pull/477)**

#### Description
* Export Layer type
* Allow tweaking encoding params per layer by using optional layer param. This can be used to disable certain layer (for example keep the high layer disabled and enable it only for the main speaker)
* Added API to select which layer should be enabled.
* Allow sending a message to 'ion-sfu' channel for the publisher to communicate layer selection
* Support new message type and layer selection callback

#### Reference issue
Fixes #...
