### PR TITLE
use provided constraints in getDisplayMedia

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -147,9 +147,7 @@ export class LocalStream extends MediaStream {
     },
   ) {
     // @ts-ignore
-    const stream = await navigator.mediaDevices.getDisplayMedia({
-      video: true,
-    });
+    const stream = await navigator.mediaDevices.getDisplayMedia(constraints);
 
     return new LocalStream(stream, {
       ...defaults,


### PR DESCRIPTION
allows audio capture in screenshare (for example in chrome when sharing a tab or the whole screen)