### PR TITLE
Add `onapiready` handler

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -64,6 +64,7 @@ export default class Client {
   private config: Configuration;
   private signal: Signal;
 
+  onapiready?: () => void;
   ontrack?: (track: MediaStreamTrack, stream: RemoteStream) => void;
   ondatachannel?: (ev: RTCDataChannelEvent) => void;
   onspeaker?: (ev: string[]) => void;
@@ -109,6 +110,9 @@ export default class Client {
             this.onspeaker(JSON.parse(e.data));
           }
         };
+        if (this.onapiready) {
+          this.onapiready();
+        }
         return;
       }
 


### PR DESCRIPTION
When joining a room there will be a brief period before the Subscriber
API data channel is established.  Methods that use the API during that
time will fail silently.  This can be a source of race conditions for
code that needs to set the initial state of streams immediately after
joining.

This change adds an `onapiready` handler that will be called once the
data channel is established, which provides a way to avoid such race
conditions.