### PR TITLE
Resolve `join` promise after API channel ready (2)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -107,21 +107,24 @@ export default class Client {
       }
     };
 
-    this.transports[Role.sub].pc.ondatachannel = (ev: RTCDataChannelEvent) => {
-      if (ev.channel.label === API_CHANNEL) {
-        this.transports![Role.sub].api = ev.channel;
-        ev.channel.onmessage = (e) => {
-          if (this.onspeaker) {
-            this.onspeaker(JSON.parse(e.data));
-          }
-        };
-        return;
-      }
+    const apiReady = new Promise<void>((resolve) => {
+      this.transports![Role.sub].pc.ondatachannel = (ev: RTCDataChannelEvent) => {
+        if (ev.channel.label === API_CHANNEL) {
+          this.transports![Role.sub].api = ev.channel;
+          ev.channel.onmessage = (e) => {
+            if (this.onspeaker) {
+              this.onspeaker(JSON.parse(e.data));
+            }
+          };
+          resolve();
+          return;
+        }
 
-      if (this.ondatachannel) {
-        this.ondatachannel(ev);
-      }
-    };
+        if (this.ondatachannel) {
+          this.ondatachannel(ev);
+        }
+      };
+    });
 
     const offer = await this.transports[Role.pub].pc.createOffer();
     await this.transports[Role.pub].pc.setLocalDescription(offer);
@@ -130,6 +133,8 @@ export default class Client {
     await this.transports[Role.pub].pc.setRemoteDescription(answer);
     this.transports[Role.pub].candidates.forEach((c) => this.transports![Role.pub].pc.addIceCandidate(c));
     this.transports[Role.pub].pc.onnegotiationneeded = this.onNegotiationNeeded.bind(this);
+
+    return apiReady;
   }
 
   leave() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -107,24 +107,21 @@ export default class Client {
       }
     };
 
-    const apiReady = new Promise<void>((resolve) => {
-      this.transports![Role.sub].pc.ondatachannel = (ev: RTCDataChannelEvent) => {
-        if (ev.channel.label === API_CHANNEL) {
-          this.transports![Role.sub].api = ev.channel;
-          ev.channel.onmessage = (e) => {
-            if (this.onspeaker) {
-              this.onspeaker(JSON.parse(e.data));
-            }
-          };
-          resolve();
-          return;
-        }
+    this.transports[Role.sub].pc.ondatachannel = (ev: RTCDataChannelEvent) => {
+      if (ev.channel.label === API_CHANNEL) {
+        this.transports![Role.sub].api = ev.channel;
+        ev.channel.onmessage = (e) => {
+          if (this.onspeaker) {
+            this.onspeaker(JSON.parse(e.data));
+          }
+        };
+        return;
+      }
 
-        if (this.ondatachannel) {
-          this.ondatachannel(ev);
-        }
-      };
-    });
+      if (this.ondatachannel) {
+        this.ondatachannel(ev);
+      }
+    };
 
     const offer = await this.transports[Role.pub].pc.createOffer();
     await this.transports[Role.pub].pc.setLocalDescription(offer);
@@ -133,8 +130,6 @@ export default class Client {
     await this.transports[Role.pub].pc.setRemoteDescription(answer);
     this.transports[Role.pub].candidates.forEach((c) => this.transports![Role.pub].pc.addIceCandidate(c));
     this.transports[Role.pub].pc.onnegotiationneeded = this.onNegotiationNeeded.bind(this);
-
-    return apiReady;
   }
 
   leave() {

--- a/src/ion.ts
+++ b/src/ion.ts
@@ -102,9 +102,9 @@ export class IonConnector {
                                                 this.ondatachannel?.call(this, ev);
                 sfu.onspeaker = (ev: string[]) => this.onspeaker?.call(this, ev);
 
-                await sfu.join(this._sid, this._uid);
-
                 this._sfu = sfu;
+
+                await sfu.join(this._sid, this._uid);
             }
         });
 


### PR DESCRIPTION
Previously, the (implicit) promise returned by `join` would resolve
after establishing the transports, but before the API data channel was
attached.  This meant there was a small window of time where the API
data channel was not ready, and trying to use the subscriber API during
that time would fail silently.

This change returns a promise that does not resolve until after the API
channel is established.

Note: this is an update to #185, to include a fix to make it work
correctly with `src/ion.ts`.