### PR TITLE
fix: `JSON.stringify` a JS `Map` always return `{}`

### DIFF
--- a/src/ion.ts
+++ b/src/ion.ts
@@ -135,7 +135,7 @@ export class IonConnector {
 
     get sfu() { return this._sfu; }
 
-    async join(sid: string, uid: string, info: Map<string, any>, token: string | undefined): Promise<JoinResult> {
+    async join(sid: string, uid: string, info: Record<string, any>, token: string | undefined): Promise<JoinResult> {
         this._sid = sid;
         this._uid = uid;
         return this._biz.join(sid, uid, info, token);

--- a/src/ion.ts
+++ b/src/ion.ts
@@ -20,7 +20,7 @@ export enum PeerState {
 export interface Peer {
     uid: string;
     sid: string;
-    info: Map<string, any>;
+    info: Record<string, any>;
 }
 
 export interface PeerEvent {
@@ -55,7 +55,7 @@ export interface Stream {
 export interface Message {
     from: string ;
     to: string;
-    data: Map<string, any>;
+    data: Record<string, any>;
 }
 
 export class IonConnector {
@@ -145,7 +145,7 @@ export class IonConnector {
         return this._biz.leave(uid)
     }
 
-    async message(from: string, to: string, data: Map<string, any>): Promise<void> {
+    async message(from: string, to: string, data: Record<string, any>): Promise<void> {
         return this._biz.sendMessage(from, to, data);
     }
 

--- a/src/signal/biz.ts
+++ b/src/signal/biz.ts
@@ -97,7 +97,7 @@ export class BizClient extends EventEmitter {
     }
 
 
-    async join(sid: string, uid: string, info: Map<string, any>, token: string | undefined): Promise<JoinResult> {
+    async join(sid: string, uid: string, info: Record<string, any>, token: string | undefined): Promise<JoinResult> {
         const request = new biz.SignalRequest();
         const join = new biz.Join();
         join.setToken(token || '');

--- a/src/signal/biz.ts
+++ b/src/signal/biz.ts
@@ -139,7 +139,7 @@ export class BizClient extends EventEmitter {
         });
     }
 
-    async sendMessage(from: string, to: string, data: Map<string, any>) {
+    async sendMessage(from: string, to: string, data: Record<string, any>) {
         const request = new biz.SignalRequest();
         const message = new ion.Message();
         message.setFrom(from);


### PR DESCRIPTION
Can't use `JSON.stringify` on a `Map` because its always return `'{}'` despite that `Map` has item.