### PR TITLE
fix(biz): leave() promise was never fulfilled

### DIFF
--- a/src/signal/biz.ts
+++ b/src/signal/biz.ts
@@ -135,9 +135,9 @@ export class BizClient extends EventEmitter {
     return new Promise<string>((resolve, reject) => {
       const handler = (reason: string) => {
         resolve(reason);
-        this.removeListener('join-reply', handler);
+        this.removeListener('leave-reply', handler);
       };
-      this.addListener('join-reply', handler);
+      this.addListener('leave-reply', handler);
     });
   }
 


### PR DESCRIPTION
BizClient.leave() promise was never fulfilled due to listening to the incorrect event

#### Description
Event should be "leave-reply" instead (as implemented in ion-sdk-flutter)
