### PR TITLE
Add optional encoding params to publish

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -170,11 +170,11 @@ export default class Client {
     return this.transports[Role.sub].pc.getStats(selector);
   }
 
-  publish(stream: LocalStream) {
+  publish(stream: LocalStream, encodingParams?: RTCRtpEncodingParameters[]) {
     if (!this.transports) {
       throw Error(ERR_NO_SESSION);
     }
-    stream.publish(this.transports[Role.pub]);
+    stream.publish(this.transports[Role.pub], encodingParams);
   }
 
   createDataChannel(label: string) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -159,6 +159,7 @@ export class LocalStream extends MediaStream {
   constraints: Constraints;
   pc?: RTCPeerConnection;
   api?: RTCDataChannel;
+  encodingParams?: RTCRtpEncodingParameters[];
 
   constructor(stream: MediaStream, constraints: Constraints) {
     super(stream);
@@ -203,50 +204,47 @@ export class LocalStream extends MediaStream {
 
   private publishTrack(track: MediaStreamTrack) {
     if (this.pc) {
-      if (track.kind === 'video' && this.constraints.simulcast) {
-        const idx = resolutions.indexOf(this.constraints.resolution);
-        const encodings: RTCRtpEncodingParameters[] = [
-          {
-            rid: 'f',
-            maxBitrate: VideoConstraints[resolutions[idx]].encodings.maxBitrate,
-            maxFramerate: VideoConstraints[resolutions[idx]].encodings.maxFramerate,
-          },
-        ];
+      const init: RTCRtpTransceiverInit = {
+        streams: [this],
+        direction: 'sendonly',
+      };
+      if (track.kind === 'video') {
+        if (this.encodingParams) {
+          init.sendEncodings = this.encodingParams
+        } else if (this.constraints.simulcast) {
+          const idx = resolutions.indexOf(this.constraints.resolution);
+          const encodings: RTCRtpEncodingParameters[] = [
+            {
+              rid: 'f',
+              maxBitrate: VideoConstraints[resolutions[idx]].encodings.maxBitrate,
+              maxFramerate: VideoConstraints[resolutions[idx]].encodings.maxFramerate,
+            },
+          ];
 
-        if (idx - 1 >= 0) {
-          encodings.push({
-            rid: 'h',
-            scaleResolutionDownBy: 2.0,
-            maxBitrate: VideoConstraints[resolutions[idx - 1]].encodings.maxBitrate,
-            maxFramerate: VideoConstraints[resolutions[idx - 1]].encodings.maxFramerate,
-          });
-        }
+          if (idx - 1 >= 0) {
+            encodings.push({
+              rid: 'h',
+              scaleResolutionDownBy: 2.0,
+              maxBitrate: VideoConstraints[resolutions[idx - 1]].encodings.maxBitrate,
+              maxFramerate: VideoConstraints[resolutions[idx - 1]].encodings.maxFramerate,
+            });
+          }
 
-        if (idx - 2 >= 0) {
-          encodings.push({
-            rid: 'q',
-            scaleResolutionDownBy: 4.0,
-            maxBitrate: VideoConstraints[resolutions[idx - 2]].encodings.maxBitrate,
-            maxFramerate: VideoConstraints[resolutions[idx - 2]].encodings.maxFramerate,
-          });
-        }
-        const transceiver = this.pc.addTransceiver(track, {
-          streams: [this],
-          direction: 'sendonly',
-          sendEncodings: encodings,
-        });
-        this.setPreferredCodec(transceiver, track.kind);
-      } else {
-        const init: RTCRtpTransceiverInit = {
-          streams: [this],
-          direction: 'sendonly',
-        };
-        if (track.kind === 'video') {
+          if (idx - 2 >= 0) {
+            encodings.push({
+              rid: 'q',
+              scaleResolutionDownBy: 4.0,
+              maxBitrate: VideoConstraints[resolutions[idx - 2]].encodings.maxBitrate,
+              maxFramerate: VideoConstraints[resolutions[idx - 2]].encodings.maxFramerate,
+            });
+          }
+          init.sendEncodings = encodings
+        } else {
           init.sendEncodings = [VideoConstraints[this.constraints.resolution].encodings];
         }
-        const transceiver = this.pc.addTransceiver(track, init);
-        this.setPreferredCodec(transceiver, track.kind);
       }
+      const transceiver = this.pc.addTransceiver(track, init);
+      this.setPreferredCodec(transceiver, track.kind);
     }
   }
 
@@ -327,9 +325,10 @@ export class LocalStream extends MediaStream {
     return stream.getVideoTracks()[0];
   }
 
-  publish(transport: Transport) {
+  publish(transport: Transport, encodingParams?: RTCRtpEncodingParameters[]) {
     this.pc = transport.pc;
     this.api = transport.api;
+    this.encodingParams = encodingParams;
     this.getTracks().forEach(this.publishTrack.bind(this));
   }
 


### PR DESCRIPTION
* Allow specifing encoding params when publishing media stream

#### Description
Adds flexibility when publishing streams. It allows users to specify optional encoding params. Example: user wants different scaling factor for simulcast. 

#### Reference issue
Fixes #...
