### PR TITLE
fix: iOS restartIce on 'failed' iceConnectionState

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -55,7 +55,8 @@ export class Transport {
     };
 
     this.pc.oniceconnectionstatechange = async (e) => {
-      if (this.pc.iceConnectionState === 'disconnected') {
+      // iOS iceConnectionState can go straight to "failed" without emitting "disconnected"
+      if (this.pc.iceConnectionState === 'disconnected' || this.pc.iceConnectionState === 'failed') {
         if (this.pc.restartIce !== undefined) {
           // this will trigger onNegotiationNeeded
           this.pc.restartIce();


### PR DESCRIPTION
#### Description

On iOS devices it is possible for the `iceconnectionstate` state to go from `checking` straight to `failed` without a `disconnected` state in between.

We should `restartIce` in this scenario.

Fixes: #232 
