### PR TITLE
 Fix microphone issues with Firefox and Safari

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -253,10 +253,6 @@ export class LocalStream extends MediaStream {
       const cap = RTCRtpSender.getCapabilities(kind);
       if (!cap) return;
       let selCodec: RTCRtpCodecCapability | undefined;
-      // 42e01f for safari/chrome/firefox cross-browser compatibility
-      if (kind === 'video' && this.constraints.codec && this.constraints.codec.toLowerCase() === 'h264') {
-        this.constraints.preferredCodecProfile = '42e01f'
-      }
       if (this.constraints.preferredCodecProfile && kind === 'video') {
         const allCodecProfiles = cap.codecs.filter(
           (c) => c.mimeType.toLowerCase() === `video/${this.constraints.codec.toLowerCase()}`,
@@ -302,8 +298,6 @@ export class LocalStream extends MediaStream {
         });
       }
     } else {
-      this.addTrack(next);
-
       if (this.pc) {
         this.publishTrack(next);
       }
@@ -359,6 +353,8 @@ export class LocalStream extends MediaStream {
     };
 
     const prev = this.getTrack(kind);
+    // Firefox/Safari have issues when multiple input devices are used by same origin. We need to stop previous track before creating new one.
+    if (prev) prev.stop()
     const next = await this.getNewTrack(kind);
 
     this.updateTrack(next, prev);


### PR DESCRIPTION
* Firefox can't open more than one microphone per process. When switching audio input devices, we need to stop using the current device before opening a new one. This also somewhat affects safari, causing "A MediaStreamTrack ended due to a capture failure" error.

* Remove overriding preferred codec profile with default.

#### Description

#### Reference issue
Fixes #...
